### PR TITLE
change cache otp key for reset password to email

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -293,7 +293,7 @@ class PasswordResetView(APIView):
 
             otp: Union[str, None] = send_reset_otp(email)
             if otp:
-                key = f"Reset_Token:{otp}"
+                key = email
                 user.reset_token = otp
                 user.save()
                 cache.set(key, otp, 60 * 10)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved OTP (One-Time Password) caching mechanism for password resets by using the user's email as the cache key instead of the OTP itself.
  
- **Bug Fixes**
	- Enhanced reliability of OTP retrieval and validation with the new email-based caching approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->