### PR TITLE
update success typo string

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -338,7 +338,7 @@ class ChangePasswordView(APIView):
                         user.reset_token = None
                         user.save()
                         return service_response(
-                            status="sucess",
+                            status="success",
                             message="Password successfully updated",
                             status_code=status.HTTP_200_OK,
                         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the spelling of "sucess" to "success" in the status message for password updates, improving response clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->